### PR TITLE
对应第08章：初始化和销毁方法，将原本在ConfigurableBeanFactory接口中的destroySingletons方法移动到…

### DIFF
--- a/small-spring-step-07/src/main/java/cn/bugstack/springframework/beans/factory/config/ConfigurableBeanFactory.java
+++ b/small-spring-step-07/src/main/java/cn/bugstack/springframework/beans/factory/config/ConfigurableBeanFactory.java
@@ -16,9 +16,5 @@ public interface ConfigurableBeanFactory extends HierarchicalBeanFactory, Single
 
     void addBeanPostProcessor(BeanPostProcessor beanPostProcessor);
 
-    /**
-     * 销毁单例对象
-     */
-    void destroySingletons();
 
 }

--- a/small-spring-step-07/src/main/java/cn/bugstack/springframework/beans/factory/config/SingletonBeanRegistry.java
+++ b/small-spring-step-07/src/main/java/cn/bugstack/springframework/beans/factory/config/SingletonBeanRegistry.java
@@ -9,5 +9,10 @@ public interface SingletonBeanRegistry {
 
     Object getSingleton(String beanName);
 
+
+    /**
+     * 销毁单例对象
+     */
+    void destroySingletons();
 }
                                                 


### PR DESCRIPTION
手写Spring第08章初始化和销毁方法图有点错误，和代码对不上。
图中DefaultSingletonBeanRegistry实现了ConfigurablebeanFactory接口，重写了destroySingltons方法，但是代码中并没有实现ConfigurablebeanFactory接口，而是实现的SingletonBeanRegistry接口

我想这个destroySingltons方法应该是定义在SingletonBeanRegistry接口