### PR TITLE
Could cn.bugstack.springframework: small-spring-step-17: 1.0-SNAPSHOT drop off redundant dependencies?

### DIFF
--- a/small-spring-step-17/pom.xml
+++ b/small-spring-step-17/pom.xml
@@ -60,12 +60,6 @@
             <artifactId>hutool-all</artifactId>
             <version>5.5.0</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.openjdk.jol/jol-cli -->
-        <dependency>
-            <groupId>org.openjdk.jol</groupId>
-            <artifactId>jol-cli</artifactId>
-            <version>0.14</version>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/org.dom4j/dom4j -->
         <dependency>
             <groupId>org.dom4j</groupId>


### PR DESCRIPTION

![1](https://user-images.githubusercontent.com/126549527/223407821-102e1550-fa5c-45bb-850e-27c8e5f72cd6.png)

Hi, I found that **_cn.bugstack.springframework: small-spring-step-17: 1.0-SNAPSHOT_**’s pom file introduced **_11_** dependencies. However, among them, **_3_** libraries (**_27%_** have not been used by your project), the redundant dependencies are listed below. 

More seriously,  **_1_**  redundant libraries have not been maintained by developers for more than **_3_** years（outdated dependencies）.

Reduce these unused dependencies can help prevent introducing bugs/vulnerabilities from outdated dependencies. Meanwhile, it can minimize the project size. To safely remove redundant dependencies, I constructed a complete call graph (resolved most of Java reflection and dynamic binding) , and validated that they have not been used by the client code.
 
This PR **_cn.bugstack.springframework: small-spring-step-17: 1.0-SNAPSHOT_** for removing the redundant dependencies have passed the tests.

Best regards

## Redundant dependencies
#### Redundant direct dependencies:
          org.openjdk.jol:jol-cli:0.14:compile [37 KB]
#### Redundant indirect dependencies:
         net.sf.jopt-simple:jopt-simple:4.6:compile [61 KB]
         org.openjdk.jol:jol-core:0.14:compile [106 KB]  

## Outdated dependencies
net.sf.jopt-simple:jopt-simple:4.6 (**_3347_** days without maintenance) 
